### PR TITLE
休講・補講・教室変更の新規追加機能と削除確認ダイアログを実装

### DIFF
--- a/src/app/dotto/cancelled-classes/CancelledClassesPageClient.tsx
+++ b/src/app/dotto/cancelled-classes/CancelledClassesPageClient.tsx
@@ -16,6 +16,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
 import { PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
 import { Plus, Search, RefreshCw, Trash2, X } from "lucide-react";
@@ -228,9 +239,27 @@ export function CancelledClassesPageClient({
                     <TableCell>{PERIOD_LABEL[item.period as Period] ?? item.period}</TableCell>
                     <TableCell>{item.comment}</TableCell>
                     <TableCell>
-                      <Button size="icon-sm" variant="ghost" onClick={() => handleDelete(item.id)}>
-                        <Trash2 className="size-4 text-red-600" />
-                      </Button>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button size="icon-sm" variant="ghost">
+                            <Trash2 className="size-4 text-red-600" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>休講を削除しますか？</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {item.subject.name} ({new Date(item.date).toLocaleDateString("ja-JP")} {PERIOD_LABEL[item.period as Period] ?? item.period}) を削除します。この操作は取り消せません。
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction variant="destructive" onClick={() => handleDelete(item.id)}>
+                              削除
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/dotto/cancelled-classes/CancelledClassesPageClient.tsx
+++ b/src/app/dotto/cancelled-classes/CancelledClassesPageClient.tsx
@@ -102,10 +102,16 @@ export function CancelledClassesPageClient({
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <span>休講管理</span>
-            <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
-              <RefreshCw className="mr-1 size-4" />
-              {isFetching ? "取得中..." : "教務から取得"}
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
+                <RefreshCw className="mr-1 size-4" />
+                {isFetching ? "取得中..." : "教務から取得"}
+              </Button>
+              <Button onClick={() => router.push("/dotto/cancelled-classes/new")}>
+                <Plus className="mr-1 size-4" />
+                新規追加
+              </Button>
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/app/dotto/cancelled-classes/actions.ts
+++ b/src/app/dotto/cancelled-classes/actions.ts
@@ -4,6 +4,7 @@ import { api } from "@/lib/api";
 import type { components } from "@/types/openapi";
 
 export type CancelledClass = components["schemas"]["AcademicService.CancelledClass"];
+export type CancelledClassRequest = components["schemas"]["AcademicService.CancelledClassRequest"];
 
 interface ListFilters {
   subjectIds?: string[];
@@ -35,6 +36,18 @@ export async function fetchFromAcademicSystem(): Promise<{
     return { fetched: [], error: `休講の取得に失敗しました (${response.status})` };
   }
   return { fetched: data.cancelledClasses };
+}
+
+export async function createCancelledClass(
+  request: CancelledClassRequest,
+): Promise<{ cancelledClass?: CancelledClass; error?: string }> {
+  const { data, error, response } = await api.POST("/v1/cancelledClasses", {
+    body: request,
+  });
+  if (error || !data) {
+    return { error: `休講の作成に失敗しました (${response.status})` };
+  }
+  return { cancelledClass: data.cancelledClass };
 }
 
 export async function deleteCancelledClass(

--- a/src/app/dotto/cancelled-classes/new/NewCancelledClassPageClient.tsx
+++ b/src/app/dotto/cancelled-classes/new/NewCancelledClassPageClient.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { AuthenticatedLayout } from "@/components/authenticated-layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PERIOD_VALUES, PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
+import { createCancelledClass, type CancelledClassRequest } from "../actions";
+
+export function NewCancelledClassPageClient() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [subjectId, setSubjectId] = useState("");
+  const [date, setDate] = useState("");
+  const [period, setPeriod] = useState("");
+  const [comment, setComment] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const request: CancelledClassRequest = {
+        subjectId,
+        date,
+        period: period as Period,
+        comment,
+      };
+      const result = await createCancelledClass(request);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("休講を作成しました");
+      router.push("/dotto/cancelled-classes");
+    } catch {
+      toast.error("エラーが発生しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/dotto/cancelled-classes">
+                休講管理
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>新規作成</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>休講を作成</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">科目ID</Label>
+                <Input
+                  id="subjectId"
+                  value={subjectId}
+                  onChange={(e) => setSubjectId(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">日付</Label>
+                <Input
+                  id="date"
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>時限</Label>
+                <Select value={period} onValueChange={setPeriod} required>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="時限を選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PERIOD_VALUES.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {PERIOD_LABEL[p]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="comment">コメント</Label>
+                <Input
+                  id="comment"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => router.push("/dotto/cancelled-classes")}
+                  disabled={isSubmitting}
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isSubmitting || !period}>
+                  {isSubmitting ? "処理中..." : "作成"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/dotto/cancelled-classes/new/page.tsx
+++ b/src/app/dotto/cancelled-classes/new/page.tsx
@@ -1,0 +1,5 @@
+import { NewCancelledClassPageClient } from "./NewCancelledClassPageClient";
+
+export default function NewCancelledClassPage() {
+  return <NewCancelledClassPageClient />;
+}

--- a/src/app/dotto/makeup-classes/MakeupClassesPageClient.tsx
+++ b/src/app/dotto/makeup-classes/MakeupClassesPageClient.tsx
@@ -102,10 +102,16 @@ export function MakeupClassesPageClient({
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <span>補講管理</span>
-            <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
-              <RefreshCw className="mr-1 size-4" />
-              {isFetching ? "取得中..." : "教務から取得"}
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
+                <RefreshCw className="mr-1 size-4" />
+                {isFetching ? "取得中..." : "教務から取得"}
+              </Button>
+              <Button onClick={() => router.push("/dotto/makeup-classes/new")}>
+                <Plus className="mr-1 size-4" />
+                新規追加
+              </Button>
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/app/dotto/makeup-classes/MakeupClassesPageClient.tsx
+++ b/src/app/dotto/makeup-classes/MakeupClassesPageClient.tsx
@@ -16,6 +16,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
 import { PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
 import { Plus, Search, RefreshCw, Trash2, X } from "lucide-react";
@@ -228,9 +239,27 @@ export function MakeupClassesPageClient({
                     <TableCell>{PERIOD_LABEL[item.period as Period] ?? item.period}</TableCell>
                     <TableCell>{item.comment}</TableCell>
                     <TableCell>
-                      <Button size="icon-sm" variant="ghost" onClick={() => handleDelete(item.id)}>
-                        <Trash2 className="size-4 text-red-600" />
-                      </Button>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button size="icon-sm" variant="ghost">
+                            <Trash2 className="size-4 text-red-600" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>補講を削除しますか？</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {item.subject.name} ({new Date(item.date).toLocaleDateString("ja-JP")} {PERIOD_LABEL[item.period as Period] ?? item.period}) を削除します。この操作は取り消せません。
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction variant="destructive" onClick={() => handleDelete(item.id)}>
+                              削除
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/dotto/makeup-classes/actions.ts
+++ b/src/app/dotto/makeup-classes/actions.ts
@@ -4,6 +4,7 @@ import { api } from "@/lib/api";
 import type { components } from "@/types/openapi";
 
 export type MakeupClass = components["schemas"]["AcademicService.MakeupClass"];
+export type MakeupClassRequest = components["schemas"]["AcademicService.MakeupClassRequest"];
 
 interface ListFilters {
   subjectIds?: string[];
@@ -35,6 +36,18 @@ export async function fetchFromAcademicSystem(): Promise<{
     return { fetched: [], error: `補講の取得に失敗しました (${response.status})` };
   }
   return { fetched: data.makeupClasses };
+}
+
+export async function createMakeupClass(
+  request: MakeupClassRequest,
+): Promise<{ makeupClass?: MakeupClass; error?: string }> {
+  const { data, error, response } = await api.POST("/v1/makeupClasses", {
+    body: request,
+  });
+  if (error || !data) {
+    return { error: `補講の作成に失敗しました (${response.status})` };
+  }
+  return { makeupClass: data.makeupClass };
 }
 
 export async function deleteMakeupClass(

--- a/src/app/dotto/makeup-classes/new/NewMakeupClassPageClient.tsx
+++ b/src/app/dotto/makeup-classes/new/NewMakeupClassPageClient.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { AuthenticatedLayout } from "@/components/authenticated-layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PERIOD_VALUES, PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
+import { createMakeupClass, type MakeupClassRequest } from "../actions";
+
+export function NewMakeupClassPageClient() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [subjectId, setSubjectId] = useState("");
+  const [date, setDate] = useState("");
+  const [period, setPeriod] = useState("");
+  const [comment, setComment] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const request: MakeupClassRequest = {
+        subjectId,
+        date,
+        period: period as Period,
+        comment,
+      };
+      const result = await createMakeupClass(request);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("補講を作成しました");
+      router.push("/dotto/makeup-classes");
+    } catch {
+      toast.error("エラーが発生しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/dotto/makeup-classes">
+                補講管理
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>新規作成</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>補講を作成</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">科目ID</Label>
+                <Input
+                  id="subjectId"
+                  value={subjectId}
+                  onChange={(e) => setSubjectId(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">日付</Label>
+                <Input
+                  id="date"
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>時限</Label>
+                <Select value={period} onValueChange={setPeriod} required>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="時限を選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PERIOD_VALUES.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {PERIOD_LABEL[p]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="comment">コメント</Label>
+                <Input
+                  id="comment"
+                  value={comment}
+                  onChange={(e) => setComment(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => router.push("/dotto/makeup-classes")}
+                  disabled={isSubmitting}
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isSubmitting || !period}>
+                  {isSubmitting ? "処理中..." : "作成"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/dotto/makeup-classes/new/page.tsx
+++ b/src/app/dotto/makeup-classes/new/page.tsx
@@ -1,0 +1,5 @@
+import { NewMakeupClassPageClient } from "./NewMakeupClassPageClient";
+
+export default function NewMakeupClassPage() {
+  return <NewMakeupClassPageClient />;
+}

--- a/src/app/dotto/room-changes/RoomChangesPageClient.tsx
+++ b/src/app/dotto/room-changes/RoomChangesPageClient.tsx
@@ -16,6 +16,17 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import { Label } from "@/components/ui/label";
 import { PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
 import { Plus, Search, RefreshCw, Trash2, X } from "lucide-react";
@@ -230,9 +241,27 @@ export function RoomChangesPageClient({
                     <TableCell>{item.originalRoom.name || "-"}</TableCell>
                     <TableCell>{item.newRoom.name || "-"}</TableCell>
                     <TableCell>
-                      <Button size="icon-sm" variant="ghost" onClick={() => handleDelete(item.id)}>
-                        <Trash2 className="size-4 text-red-600" />
-                      </Button>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <Button size="icon-sm" variant="ghost">
+                            <Trash2 className="size-4 text-red-600" />
+                          </Button>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>教室変更を削除しますか？</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              {item.subject.name} ({new Date(item.date).toLocaleDateString("ja-JP")} {PERIOD_LABEL[item.period as Period] ?? item.period}) を削除します。この操作は取り消せません。
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>キャンセル</AlertDialogCancel>
+                            <AlertDialogAction variant="destructive" onClick={() => handleDelete(item.id)}>
+                              削除
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/app/dotto/room-changes/RoomChangesPageClient.tsx
+++ b/src/app/dotto/room-changes/RoomChangesPageClient.tsx
@@ -102,10 +102,16 @@ export function RoomChangesPageClient({
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             <span>教室変更管理</span>
-            <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
-              <RefreshCw className="mr-1 size-4" />
-              {isFetching ? "取得中..." : "教務から取得"}
-            </Button>
+            <div className="flex gap-2">
+              <Button variant="outline" onClick={handleFetch} disabled={isFetching}>
+                <RefreshCw className="mr-1 size-4" />
+                {isFetching ? "取得中..." : "教務から取得"}
+              </Button>
+              <Button onClick={() => router.push("/dotto/room-changes/new")}>
+                <Plus className="mr-1 size-4" />
+                新規追加
+              </Button>
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-4">

--- a/src/app/dotto/room-changes/actions.ts
+++ b/src/app/dotto/room-changes/actions.ts
@@ -4,6 +4,7 @@ import { api } from "@/lib/api";
 import type { components } from "@/types/openapi";
 
 export type RoomChange = components["schemas"]["AcademicService.RoomChange"];
+export type RoomChangeRequest = components["schemas"]["AcademicService.RoomChangeRequest"];
 
 interface ListFilters {
   subjectIds?: string[];
@@ -35,6 +36,18 @@ export async function fetchFromAcademicSystem(): Promise<{
     return { fetched: [], error: `教室変更の取得に失敗しました (${response.status})` };
   }
   return { fetched: data.roomChanges };
+}
+
+export async function createRoomChange(
+  request: RoomChangeRequest,
+): Promise<{ roomChange?: RoomChange; error?: string }> {
+  const { data, error, response } = await api.POST("/v1/roomChanges", {
+    body: request,
+  });
+  if (error || !data) {
+    return { error: `教室変更の作成に失敗しました (${response.status})` };
+  }
+  return { roomChange: data.roomChange };
 }
 
 export async function deleteRoomChange(

--- a/src/app/dotto/room-changes/new/NewRoomChangePageClient.tsx
+++ b/src/app/dotto/room-changes/new/NewRoomChangePageClient.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { AuthenticatedLayout } from "@/components/authenticated-layout";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from "@/components/ui/breadcrumb";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { PERIOD_VALUES, PERIOD_LABEL, type Period } from "@/app/dotto/timetable/constants";
+import { createRoomChange, type RoomChangeRequest } from "../actions";
+
+export function NewRoomChangePageClient() {
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [subjectId, setSubjectId] = useState("");
+  const [date, setDate] = useState("");
+  const [period, setPeriod] = useState("");
+  const [originalRoomId, setOriginalRoomId] = useState("");
+  const [newRoomId, setNewRoomId] = useState("");
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      const request: RoomChangeRequest = {
+        subjectId,
+        date,
+        period: period as Period,
+        originalRoomId,
+        newRoomId,
+      };
+      const result = await createRoomChange(request);
+      if (result.error) {
+        toast.error(result.error);
+        return;
+      }
+      toast.success("教室変更を作成しました");
+      router.push("/dotto/room-changes");
+    } catch {
+      toast.error("エラーが発生しました");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <AuthenticatedLayout>
+      <div className="space-y-4">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink href="/dotto/room-changes">
+                教室変更管理
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>新規作成</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>教室変更を作成</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="subjectId">科目ID</Label>
+                <Input
+                  id="subjectId"
+                  value={subjectId}
+                  onChange={(e) => setSubjectId(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="date">日付</Label>
+                <Input
+                  id="date"
+                  type="date"
+                  value={date}
+                  onChange={(e) => setDate(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>時限</Label>
+                <Select value={period} onValueChange={setPeriod} required>
+                  <SelectTrigger className="w-full">
+                    <SelectValue placeholder="時限を選択" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {PERIOD_VALUES.map((p) => (
+                      <SelectItem key={p} value={p}>
+                        {PERIOD_LABEL[p]}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="originalRoomId">変更前の教室ID</Label>
+                <Input
+                  id="originalRoomId"
+                  value={originalRoomId}
+                  onChange={(e) => setOriginalRoomId(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="newRoomId">変更後の教室ID</Label>
+                <Input
+                  id="newRoomId"
+                  value={newRoomId}
+                  onChange={(e) => setNewRoomId(e.target.value)}
+                  required
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => router.push("/dotto/room-changes")}
+                  disabled={isSubmitting}
+                >
+                  キャンセル
+                </Button>
+                <Button type="submit" disabled={isSubmitting || !period}>
+                  {isSubmitting ? "処理中..." : "作成"}
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </AuthenticatedLayout>
+  );
+}

--- a/src/app/dotto/room-changes/new/page.tsx
+++ b/src/app/dotto/room-changes/new/page.tsx
@@ -1,0 +1,5 @@
+import { NewRoomChangePageClient } from "./NewRoomChangePageClient";
+
+export default function NewRoomChangePage() {
+  return <NewRoomChangePageClient />;
+}


### PR DESCRIPTION
## 概要

休講・補講・教室変更の管理画面に新規追加機能と削除確認ダイアログを追加しました。

## 変更内容

- 休講・補講・教室変更の新規作成ページ (`/new`) を追加
- 各一覧ページのヘッダーに「新規追加」ボタンを配置
- 各エンティティの `create` サーバーアクションを追加
- 削除ボタンに AlertDialog による確認ダイアログを追加（誤操作防止）

## テスト計画

- [ ] 休講の新規作成が正常に動作すること
- [ ] 補講の新規作成が正常に動作すること
- [ ] 教室変更の新規作成が正常に動作すること
- [ ] 各一覧ページの新規追加ボタンから作成ページに遷移すること
- [ ] 削除ボタン押下時に確認ダイアログが表示されること
- [ ] 確認ダイアログでキャンセルすると削除されないこと
- [ ] 確認ダイアログで削除すると正常に削除されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)