### PR TITLE
/__/auth/handlerのプロキシ設定追加

### DIFF
--- a/src/app/%5F%5F/auth/[...path]/route.ts
+++ b/src/app/%5F%5F/auth/[...path]/route.ts
@@ -1,0 +1,39 @@
+type RouteContext = {
+  params: Promise<{
+    path?: string[];
+  }>;
+};
+
+const firebaseAuthHelperOrigin = "https://swift2023groupc.firebaseapp.com";
+
+async function proxyFirebaseAuthHelper(
+  request: Request,
+  { params }: RouteContext,
+): Promise<Response> {
+  const { path = [] } = await params;
+  const requestUrl = new URL(request.url);
+  const targetUrl = new URL(
+    `/__/auth/${path.join("/")}${requestUrl.search}`,
+    firebaseAuthHelperOrigin,
+  );
+
+  return fetch(
+    new Request(targetUrl, {
+      method: request.method,
+      headers: request.headers,
+      body:
+        request.method === "GET" || request.method === "HEAD"
+          ? undefined
+          : request.body,
+      redirect: "manual",
+    }),
+  );
+}
+
+export const GET = proxyFirebaseAuthHelper;
+export const POST = proxyFirebaseAuthHelper;
+export const PUT = proxyFirebaseAuthHelper;
+export const PATCH = proxyFirebaseAuthHelper;
+export const DELETE = proxyFirebaseAuthHelper;
+export const OPTIONS = proxyFirebaseAuthHelper;
+export const HEAD = proxyFirebaseAuthHelper;


### PR DESCRIPTION
## やったこと
/__/auth/handlerへのリクエストをFirebaseドメインのパスに転送する処理を追加

## 確認したこと
なし
デプロイ後にモバイルから確認する

## コメント
- [公式](https://firebase.google.com/docs/auth/web/redirect-best-practices)見た感じ，モバイルはPopup，Redirectどっちでも良さそうだけともしかしたらうまくいかないかも
- 多分PCはは大丈夫なはず